### PR TITLE
Add option to import shoebot libraries

### DIFF
--- a/README
+++ b/README
@@ -10,14 +10,14 @@ Shoebot extension for Sphinx
 About
 =====
 
-This extensions allows rendering of shoebot bots using python_.
+This extension allows rendering of Shoebot scripts using python_.
 
-This extensions adds the ``shoebot`` directive that will replace the shoebot
-commands with the image of the graphics bot.
+It adds the ``shoebot`` directive, which renders the script contents into
+an image and displays it alongside the script source.
 
 
-Quick Example
--------------
+Example
+-------
 
 This source::
 
@@ -86,6 +86,3 @@ Just add ``sphinxcontrib.shoebot`` to the list of extensions in the ``conf.py``
 file. For example::
 
     extensions = ['sphinxcontrib.shoebot']
-
-
-

--- a/README
+++ b/README
@@ -41,21 +41,26 @@ The directive 'snapshot' specifies that it will generate a single image.
 Options
 -------
 
-Size - change the size of the rendered bot.
+The **size** option is used to change the canvas size without including the
+size() command in the script itself.
 
     .. shoebot::
         :size: 400, 400
 
         # On a 400x400 canvas draw some rectangles
-        def draw():
-            nofill()
-            strokewidth(20)
-            stroke(0.75, 0., 0)
-            for i in range(380, 0, -40):
-                rect(200-i, 200-i, i*2, i*2)
+        nofill()
+        strokewidth(20)
+        stroke(0.75, 0., 0)
+        for i in range(380, 0, -40):
+            rect(200-i, 200-i, i*2, i*2)
 
-Used to change the canvas size without including 'size' in the
-script itself.
+
+The **ximports** option takes care of importing Shoebot libraries, specified
+in a comma-separated sequence without quotes or brackets.
+
+    .. shoebot::
+        :ximports: cornu, colors, photobot
+
 
 Requirements
 ------------

--- a/sphinxcontrib/shoebot.py
+++ b/sphinxcontrib/shoebot.py
@@ -62,6 +62,13 @@ def size_option(argument):
     raise ArgumentError("Expected size to be str or tuple")
 
 
+def ximports_option(argument):
+    """Decode the ximports option"""
+    if isinstance(argument, str):
+        return [l for l in argument.strip(" ()").split(",") if l]
+    raise ArgumentError("Expected a comma-separated list of libraries")
+
+
 class ShoebotDirective(Directive):
     """Source code syntax highlighting."""
 
@@ -69,7 +76,13 @@ class ShoebotDirective(Directive):
     optional_arguments = 1
     final_argument_whitespace = True
 
-    option_spec = {"alt": str, "filename": str, "size": size_option, "source": str}
+    option_spec = {
+        "alt": str,
+        "filename": str,
+        "size": size_option,
+        "source": str,
+        "ximports": ximports_option,
+    }
     has_content = True
 
     def run(self):
@@ -83,6 +96,7 @@ class ShoebotDirective(Directive):
 
         options_dict = dict(self.options)
         image_size = options_dict.get("size", (100, 100))
+        ximports = options_dict.get("ximports", "")
 
         output_image = options_dict.get("filename") or get_hashid(source_code)
         output_dir = os.path.normpath(f"{env.srcdir}/../build-images/examples")
@@ -98,6 +112,8 @@ class ShoebotDirective(Directive):
 
         with open(output_filename, "wb") as outfile:
             bot = shoebot.create_bot(buff=outfile, format="png")
+            for libname in ximports:
+                bot.ximport(libname)
             bot.run(script_to_render)
 
         image_node = nodes.image(uri=f"/../build-images/examples/{output_image}")


### PR DESCRIPTION
This PR adds the "ximports" option, see the README changes for how it works.