### PR TITLE
WIP - Make plugin a port of sphinxcontrib-graphviz, since that plugin…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx>=2.0.0
 sphinx-rtd-theme

--- a/sphinxcontrib/shoebot.py
+++ b/sphinxcontrib/shoebot.py
@@ -1,113 +1,443 @@
-# -*- coding: utf-8 -*-
 """
-    Derived from the Pygments reStructuredText directive
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    sphinx.ext.shoebot
+    ~~~~~~~~~~~~~~~~~~~
 
-    http://docutils.sourceforge.net/docs/howto/rst-directives.html
+    Allow shoebot-formatted graphs to be included in Sphinx-generated
+    documents inline.
 
-    :copyright: (for reStructuredText directive ) Pygments Copyright 2006-2009 by the Pygments team, see AUTHORS.
+    :copyright: Copyright 2007-2022 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import os
-
-from docutils import nodes
-from docutils.parsers.rst import directives, Directive
-
-from pygments import highlight
-from pygments.lexers import PythonLexer
-from pygments.formatters import HtmlFormatter
-
-from sphinx.errors import SphinxError
-from sphinx.util import ensuredir
-
 from hashlib import sha1
 
-import shoebot
+import os
+import posixpath
+import re
+import subprocess
+from os import path
+from subprocess import PIPE, CalledProcessError
+from typing import Any, Dict, List, Tuple, Union
 
-# Options
-# ~~~~~~~
+import ipdb
+from docutils import nodes
+from docutils.nodes import Node
+from docutils.parsers.rst import Directive, directives
 
-# Set to True if you want inline CSS styles instead of classes
-INLINESTYLES = False
+from pygments import highlight
+from pygments.lexers.python import PythonLexer
+from pygments.formatters.html import HtmlFormatter
+from pygments.formatters.latex import LatexFormatter
 
-# The default formatter
-DEFAULT = HtmlFormatter(noclasses=INLINESTYLES)
+import sphinx
+from shoebot import create_bot
+from sphinx.application import Sphinx
+from sphinx.errors import SphinxError
+from sphinx.locale import _, __
+from sphinx.util import logging
+from sphinx.util.docutils import SphinxDirective, SphinxTranslator
+from sphinx.util.nodes import set_source_info
+from sphinx.util.osutil import ensuredir
+from sphinx.util.typing import OptionSpec
+from sphinx.writers.html import HTMLTranslator
+from sphinx.writers.latex import LaTeXTranslator
+from sphinx.writers.manpage import ManualPageTranslator
+from sphinx.writers.texinfo import TexinfoTranslator
+from sphinx.writers.text import TextTranslator
 
-# Extra code added to every bot
-BOT_PRESET_SOURCE_CODE = """
-size{size}
-background(1)
-"""
-
-
-def get_hashid(text):
-    return sha1(text.encode("utf-8")).hexdigest()
+logger = logging.getLogger(__name__)
 
 
 class ShoebotError(SphinxError):
-    category = "shoebot error"
+    category = "Shoebot error"
 
 
-def align(argument):
-    """Conversion function for the "align" option."""
+# class shoebot_code(nodes.General, nodes.Inline, nodes.Element):
+#     pass
+
+
+class shoebot(nodes.General, nodes.Inline, nodes.Element):
+    pass
+
+
+def figure_wrapper(directive: Directive, node: shoebot, caption: str) -> nodes.figure:
+    figure_node = nodes.figure("", node)
+    if "align" in node:
+        figure_node["align"] = node.attributes.pop("align")
+
+    inodes, messages = directive.state.inline_text(caption, directive.lineno)
+    caption_node = nodes.caption(caption, "", *inodes)
+    caption_node.extend(messages)
+    set_source_info(directive, caption_node)
+    figure_node += caption_node
+    return figure_node
+
+
+def align_spec(argument: Any) -> str:
     return directives.choice(argument, ("left", "center", "right"))
 
 
-def size_option(argument):
+def size_spec(argument):
     """Decode the size option"""
     if isinstance(argument, tuple):
         return argument
     if isinstance(argument, str):
         return tuple(map(int, argument.split(",")))
-    raise ArgumentError("Expected size to be str or tuple")
+    raise ValueError("Expected size to be str or tuple")
 
 
-class ShoebotDirective(Directive):
-    """Source code syntax highlighting."""
+def ximports_spec(argument):
+    """Decode the ximports option"""
+    if isinstance(argument, str):
+        return [l for l in argument.strip(" ()").split(",") if l]
+    raise ValueError("Expected a comma-separated list of libraries")
 
+
+class Shoebot(SphinxDirective):
+    """
+    Directive to insert arbitrary shoebot markup.
+    """
+
+    has_content = True
     required_arguments = 0
     optional_arguments = 1
-    final_argument_whitespace = True
+    final_argument_whitespace = False
+    option_spec: OptionSpec = {
+        "alt": directives.unchanged,
+        "align": align_spec,
+        # 'caption': directives.unchanged,
+        # 'layout': directives.unchanged,
+        # 'name': directives.unchanged,
+        # 'class': directives.class_option,
+        "size": size_spec,
+        "ximports": ximports_spec,
+        "filename": directives.unchanged,  # TODO - remove.
+    }
 
-    option_spec = {"alt": str, "filename": str, "size": size_option, "source": str}
-    has_content = True
+    def run(self) -> List[Node]:
+        if self.arguments:
+            document = self.state.document
+            if self.content:
+                return [
+                    document.reporter.warning(
+                        __(
+                            "Shoebot directive cannot have both content and "
+                            "a filename argument"
+                        ),
+                        line=self.lineno,
+                    )
+                ]
 
-    def run(self):
-        self.assert_has_content()
+            # TODO - filename as first param, should add search paths
+            #        so this can work with examples.
+            raise NotImplemented("TODO filename as first param")
+            # rel_filename, filename = self.env.relfn2path(self.arguments[0])
+            # self.env.note_dependency(rel_filename)
+            # try:
+            #     with open(filename, encoding='utf-8') as fp:
+            #         source_code = fp.read()
+            # except OSError:
+            #     return [document.reporter.warning(
+            #         __('External Shoebot file %r not found or reading '
+            #            'it failed') % filename, line=self.lineno)]
+        else:
+            source_code = "\n".join(self.content)
+            rel_filename = None
+            if not source_code.strip():
+                return [
+                    self.state_machine.reporter.warning(
+                        __('Ignoring "shoebot" directive without content.'),
+                        line=self.lineno,
+                    )
+                ]
 
-        env = self.state.document.settings.env
+        node = shoebot()
+        node["code"] = source_code
+        node["options"] = {"docname": self.env.docname}
 
-        source_code = "\n".join(self.content)
-        parsed_code = highlight(source_code, PythonLexer(), HtmlFormatter())
-        result = [nodes.raw("", parsed_code, format="html")]
+        if "ximports" in self.options:
+            node['options']['ximports'] = self.options['ximports']
 
-        options_dict = dict(self.options)
-        image_size = options_dict.get("size", (100, 100))
+        if "size" in self.options:
+            node['options']['size'] = self.options['size']
 
-        output_image = options_dict.get("filename") or get_hashid(source_code)
-        output_dir = os.path.normpath(f"{env.srcdir}/../build-images/examples")
+        # TODO - can support external shoebot ??
+        # if 'shoebot_cmd' in self.options:
+        #     node['options']['shoebot_cmd'] = self.options['shoebot_cmd']
+        # if 'layout' in self.options:
+        #     node['options']['shoebot_cmd'] = self.options['layout']
+        if "alt" in self.options:
+            node["alt"] = self.options["alt"]
+        if "align" in self.options:
+            node["align"] = self.options["align"]
+        # if 'class' in self.options:
+        #     node['classes'] = self.options['class']
+        if rel_filename:
+            node["filename"] = rel_filename
 
-        ensuredir(output_dir)
-
-        script_to_render = BOT_PRESET_SOURCE_CODE.format(size=image_size) + source_code
-        output_filename = os.path.join(output_dir, output_image)
-        try:
-            os.unlink(output_filename)
-        except FileNotFoundError:
-            pass
-
-        with open(output_filename, "wb") as outfile:
-            bot = shoebot.create_bot(buff=outfile, format="png")
-            bot.run(script_to_render)
-
-        image_node = nodes.image(uri=f"/../build-images/examples/{output_image}")
-        result.insert(0, image_node)
-
-        return result
-
-
-def setup(app):
-    pass
+        # if 'caption' not in self.options:
+        self.add_name(node)
+        return [node]
+        # else:
+        #     figure = figure_wrapper(self, node, self.options['caption'])
+        #     self.add_name(figure)
+        #     return [figure]
 
 
-directives.register_directive("shoebot", ShoebotDirective)
+def get_hashid(text):
+    return sha1(text.encode("utf-8")).hexdigest().encode("utf-8")
+
+
+def render_shoebot(
+    self: SphinxTranslator,
+    code: str,
+    options: Dict,
+    format: str,
+    prefix: str = "shoebot",
+    filename: str = None,
+) -> Union[Tuple[str, Union[bytes, str]], tuple[None, None]]:
+    """Render shoebot code into a PNG or PDF output file."""
+    # shoebot_cmd = options.get('shoebot_cmd', self.builder.config.shoebot_cmd)
+
+    # TODO - add image paths - or just allow setting cwd ??
+
+    shoebot_cmd = "sbot"
+    size = options.get("size", (100, 100))
+    ximports = options.get("ximports", [])
+    # hashkey = (code + str(options) + str(shoebot_cmd) +
+    #           str(self.builder.config.shoebot_cmd_args)).encode()
+    hashkey = get_hashid(code)
+
+    fname = "%s-%s.%s" % (prefix, sha1(hashkey).hexdigest(), format)
+    relfn = posixpath.join(self.builder.imgpath, fname)
+    outfn = path.join(self.builder.outdir, self.builder.imagedir, fname)
+
+    if path.isfile(outfn):
+        return relfn, outfn
+
+    if hasattr(
+        self.builder, "_shoebot_warned_shoebot"
+    ) and self.builder._shoebot_warned_shoebot.get(
+        shoebot_cmd
+    ):  # type: ignore  # NOQA
+        return None, None
+
+    ensuredir(path.dirname(outfn))
+
+    # shoebot_args = [shoebot_cmd]
+    # shoebot_args.extend(self.builder.config.shoebot_cmd_args)
+    # shoebot_args.extend(['-T' + format, '-o' + outfn])
+
+    docname = options.get("docname", "index")
+    if "SPHINXCONTRIB_SHOEBOT_CWD" in os.environ:
+        # TODO ^ use source dir from sphinx
+        cwd = os.environ["SPHINXCONTRIB_SHOEBOT_CWD"]
+    else:
+        if filename:
+            cwd = path.dirname(path.join(self.builder.srcdir, filename))
+        else:
+            cwd = path.dirname(path.join(self.builder.srcdir, docname))
+
+    _cwd = os.getcwd()
+    os.chdir(cwd)
+    with open(outfn, "wb") as f:
+        bot = create_bot(buff=f, format=format)
+        bot.size(*size)
+        bot.background(1)
+        for libname in ximports:
+            bot.ximport(libname)
+        # if not bot.run(code):
+        #     raise Exception("Bot failed")   # TODO, by default .run should probably raise exceptions.
+
+    os.chdir(_cwd)
+
+    # if format == 'png':
+    #     shoebot_args.extend(['-Tcmapx', '-o%s.map' % outfn])
+    #
+    # try:
+    #     ret = subprocess.run(shoebot_args, input=code.encode(), stdout=PIPE, stderr=PIPE,
+    #                          cwd=cwd, check=True)
+    if True:
+        if not path.isfile(outfn):
+            raise ShoebotError(
+                __("shoebot did not produce an output file: %s %s" % (_cwd, outfn))
+            )
+            # raise ShoebotError(__('shoebot did not produce an output file:\n[stderr]\n%r\n'
+            #                        '[stdout]\n%r') % (ret.stderr, ret.stdout))
+        return relfn, outfn
+    # except OSError:
+    #     logger.warning(__('shoebot command %r cannot be run (needed for shoebot '
+    #                       'output), check the shoebot_cmd setting'), shoebot_cmd)
+    #     if not hasattr(self.builder, '_shoebot_warned_shoebot'):
+    #         self.builder._shoebot_warned_shoebot = {}  # type: ignore
+    #     self.builder._shoebot_warned_shoebot[shoebot_cmd] = True  # type: ignore
+    #     return None, None
+    # except CalledProcessError as exc:
+    #     raise ShoebotError(__('shoebot exited with error:\n[stderr]\n%r\n'
+    #                            '[stdout]\n%r') % (exc.stderr, exc.stdout)) from exc
+
+
+def render_shoebot_html(
+    self: HTMLTranslator,
+    node: shoebot,
+    code: str,
+    options: Dict,
+    prefix: str = "shoebot",
+    imgcls: str = None,
+    alt: str = None,
+    filename: str = None,
+) -> Tuple[str, str]:
+    format = self.builder.config.shoebot_output_format
+    try:
+        if format not in ("png", "svg"):
+            raise ShoebotError(
+                __("shoebot_output_format must be one of 'png', " "'svg', but is %r")
+                % format
+            )
+        fname, outfn = render_shoebot(self, code, options, format, prefix, filename)
+    except ShoebotError as exc:
+        logger.warning(__("shoebot code %r: %s"), code, exc)
+        raise nodes.SkipNode from exc
+
+    classes = [imgcls, "shoebot"] + node.get("classes", [])
+    imgcls = " ".join(filter(None, classes))
+
+    if fname is None:
+        self.body.append(self.encode(code))
+    else:
+        parsed_code = highlight(
+            code, PythonLexer(), HtmlFormatter()
+        )  # Copied from shoebot
+
+        if alt is None:
+            alt = node.get("alt", self.encode(code).strip())
+
+        if "align" in node:
+            self.body.append(
+                '<div align="%s" class="align-%s">' % (node["align"], node["align"])
+            )
+        if format == "svg":
+            self.body.append('<div class="shoebot">')
+            self.body.append(
+                '<object data="%s" type="image/svg+xml" class="%s">\n' % (fname, imgcls)
+            )
+            self.body.append('<p class="warning">%s</p>' % alt)
+            self.body.append("</object>\n")
+            self.body.append(parsed_code + "\n")
+            self.body.append("</div>\n")
+        elif format == "png":
+            self.body.append('<div class="shoebot">')
+            self.body.append(
+                '<img src="%s" alt="%s" class="%s" />' % (fname, alt, imgcls)
+            )
+            self.body.append(parsed_code + "\n")
+            self.body.append("</div>\n")
+        else:
+            raise NotImplemented("Format not implemented %s" % format)
+
+        if "align" in node:
+            self.body.append("</div>\n")
+
+    raise nodes.SkipNode
+
+
+def html_visit_shoebot(self: HTMLTranslator, node: shoebot) -> None:
+    render_shoebot_html(
+        self, node, node["code"], node["options"], filename=node.get("filename")
+    )
+
+
+def render_shoebot_latex(
+    self: LaTeXTranslator,
+    node: shoebot,
+    code: str,
+    options: Dict,
+    prefix: str = "shoebot",
+    filename: str = None,
+    **kwargs,
+) -> None:
+    try:
+        fname, outfn = render_shoebot(self, code, options, "pdf", prefix, filename)
+    except ShoebotError as exc:
+        logger.warning(__("shoebot code %r: %s"), code, exc)
+        raise nodes.SkipNode from exc
+
+    is_inline = self.is_inline(node)
+
+    if not is_inline:
+        pre = ""
+        post = ""
+        if "align" in node:
+            if node["align"] == "left":
+                pre = "{"
+                post = r"\hspace*{\fill}}"
+            elif node["align"] == "right":
+                pre = r"{\hspace*{\fill}"
+                post = "}"
+            elif node["align"] == "center":
+                pre = r"{\hfill"
+                post = r"\hspace*{\fill}}"
+        self.body.append("\n%s" % pre)
+
+    self.body.append(r"\sphinxincludegraphics[]{%s}" % fname)
+
+    if not is_inline:
+        self.body.append("%s\n" % post)
+
+    raise nodes.SkipNode
+
+
+def latex_visit_shoebot(self: LaTeXTranslator, node: shoebot) -> None:
+    render_shoebot_latex(
+        self, node, node["code"], node["options"], filename=node.get("filename")
+    )
+
+
+def render_shoebot_texinfo(
+    self: TexinfoTranslator,
+    node: shoebot,
+    code: str,
+    options: Dict,
+    prefix: str = "shoebot",
+) -> None:
+    try:
+        fname, outfn = render_shoebot(self, code, options, "png", prefix)
+    except ShoebotError as exc:
+        logger.warning(__("shoebot code %r: %s"), code, exc)
+        raise nodes.SkipNode from exc
+    if fname is not None:
+        self.body.append("@image{%s,,,[shoebot],png}\n" % fname[:-4])
+    raise nodes.SkipNode
+
+
+def texinfo_visit_shoebot(self: TexinfoTranslator, node: shoebot) -> None:
+    render_shoebot_texinfo(self, node, node["code"], node["options"])
+
+
+def text_visit_shoebot(self: TextTranslator, node: shoebot) -> None:
+    if "alt" in node.attributes:
+        self.add_text(_("[shoebot: %s]") % node["alt"])
+    else:
+        self.add_text(_("[shoebot]"))
+    raise nodes.SkipNode
+
+
+def man_visit_shoebot(self: ManualPageTranslator, node: shoebot) -> None:
+    if "alt" in node.attributes:
+        self.body.append(_("[shoebot: %s]") % node["alt"])
+    else:
+        self.body.append(_("[shoebot]"))
+    raise nodes.SkipNode
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_node(
+        shoebot,
+        html=(html_visit_shoebot, None),
+        latex=(latex_visit_shoebot, None),
+        texinfo=(texinfo_visit_shoebot, None),
+        text=(text_visit_shoebot, None),
+        man=(man_visit_shoebot, None),
+    )
+    app.add_directive("shoebot", Shoebot)
+    app.add_config_value("shoebot_output_format", "png", "html")
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}


### PR DESCRIPTION
WIP - do not merge !

This is a (very) rough start at making sphinx-shoebot be a port of graphviz-shoebot.

sphinxcontrib-graphviz is a plugin by the sphinx org which uses code to render images, so is suitable to alter to render shoebot plots.

Advantages:
-  support formats other than html (still to port)
-  properly outputs images to the build directory (lack of images on readthedocs was a side effect).

Currently this just proves the concept works.

Sample:
https://shoebot.readthedocs.io/en/feature-readthedocs-temporary-fix/

html output:
  - Fix CSS (structure has changed so styling needs updating)

latex output:
  TODO

pdf output:
  TODO

man page output
  - Initial version implemented.

text outpit
- Initial version implemented
